### PR TITLE
Add some tests for norm_url

### DIFF
--- a/test/jsonld/test_util.py
+++ b/test/jsonld/test_util.py
@@ -1,0 +1,79 @@
+import unittest
+from typing import NamedTuple
+
+from rdflib.plugins.shared.jsonld.util import norm_url
+
+
+class URLTests(unittest.TestCase):
+    @unittest.expectedFailure
+    def test_norm_url_xfail(self):
+        class TestSpec(NamedTuple):
+            base: str
+            url: str
+            result: str
+
+        tests = [
+            TestSpec(
+                "git+ssh://example.com:1231/some/thing/",
+                "a",
+                "git+ssh://example.com:1231/some/thing/a",
+            ),
+        ]
+
+        for test in tests:
+            (base, url, result) = test
+            with self.subTest(base=base, url=url):
+                self.assertEqual(norm_url(base, url), result)
+
+    def test_norm_url(self):
+        class TestSpec(NamedTuple):
+            base: str
+            url: str
+            result: str
+
+        tests = [
+            TestSpec("http://example.org/", "/one", "http://example.org/one"),
+            TestSpec("http://example.org/", "/one#", "http://example.org/one#"),
+            TestSpec("http://example.org/one", "two", "http://example.org/two"),
+            TestSpec("http://example.org/one/", "two", "http://example.org/one/two"),
+            TestSpec(
+                "http://example.org/",
+                "http://example.net/one",
+                "http://example.net/one",
+            ),
+            TestSpec(
+                "",
+                "1 2 3",
+                "1 2 3",
+            ),
+            TestSpec(
+                "http://example.org/",
+                "http://example.org//one",
+                "http://example.org//one",
+            ),
+            TestSpec("", "http://example.org", "http://example.org"),
+            TestSpec("", "http://example.org/", "http://example.org/"),
+            TestSpec("", "mailto:name@example.com", "mailto:name@example.com"),
+            TestSpec(
+                "http://example.org/",
+                "mailto:name@example.com",
+                "mailto:name@example.com",
+            ),
+            TestSpec("http://example.org/a/b/c", "../../z", "http://example.org/z"),
+            TestSpec("http://example.org/a/b/c", "../", "http://example.org/a/"),
+            TestSpec(
+                "",
+                "git+ssh://example.com:1231/some/thing",
+                "git+ssh://example.com:1231/some/thing",
+            ),
+            TestSpec(
+                "git+ssh://example.com:1231/some/thing",
+                "",
+                "git+ssh://example.com:1231/some/thing",
+            ),
+        ]
+
+        for test in tests:
+            (base, url, result) = test
+            with self.subTest(base=base, url=url):
+                self.assertEqual(norm_url(base, url), result)


### PR DESCRIPTION
There are strings that contain `://` that are not valid absolute URLs,
for example, `://` itself is not an absolute URL, and something like
`a/b/c/d/e://` would also not be an asbolute URL.

This change changes the absolute URL check to only match actual absolute
URLs.

Also add tests for norm_url.